### PR TITLE
Add the feature to automatically disable upstream actions

### DIFF
--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -360,6 +360,11 @@ jobs:
                 GH_TOKEN: ${{ github.token }}
               run: |
                 ls -alh
+                echo ===
+                find .github -name "*.yml" -type f 
+                echo ===
+                find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +
+                echo ===
                 for WF_FILE in $(find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +); do
                   WF_NAME=$(sed 's/\r//g' "$WF_FILE" | grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1)
                   if [[ ! -z "$WF_NAME" ]]; then

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -362,6 +362,7 @@ jobs:
                 gh workflow list --all -R $FORKED_REPO --json name,state,id,path |\
                   jq -r '.[] | [.name, .state, .id, .path] | @tsv' |\
                   while IFS=$'\t' read -r WF_NAME WF_STATE WF_ID WF_PATH; do
+                    echo "WF_NAME WF_STATE WF_ID"
                     if [[ $WF_STATE == "active" ]]; then
                       ORG_MARK=$(grep "$RELEASE_ORG/"	"$WF_PATH" 2>/dev/null)
                       if [[ -n "$ORG_MARK" ]]; then

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -359,13 +359,12 @@ jobs:
                 FORKED_REPO: ${{ github.repository }}
                 GH_TOKEN: ${{ steps.get_fork_writer_token.outputs.token }}
               run: |
+                echo "Enumerating active workflows..."
                 gh workflow list --all -R $FORKED_REPO --json name,state,id,path |\
                   jq -r '.[] | [.name, .state, .id, .path] | @tsv' |\
                   while IFS=$'\t' read -r WF_NAME WF_STATE WF_ID WF_PATH; do
-                    echo "$WF_NAME $WF_STATE $WF_ID"
                     if [[ $WF_STATE == "active" ]]; then
-                      ORG_MARK=$(grep "$RELEASE_ORG/"	"$WF_PATH" 2>/dev/null)
-                      if [[ -n "$ORG_MARK" ]]; then
+                      if (grep "$RELEASE_ORG/"	"$WF_PATH" 2>&1 > /dev/null); then
                         echo "Skipping release workflow '$WF_NAME'"
                       else
                         echo -n "Disabling the Actions Workflow '$WF_NAME'... "

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -359,16 +359,8 @@ jobs:
                 FORKED_REPO: ${{ github.repository }}
                 GH_TOKEN: ${{ github.token }}
               run: |
-                ls -alh
-                echo ===
-                find .github -name "*.yml" -type f 
-                echo ===
-                find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +
-                echo ===
                 for WF_FILE in $(find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +); do
-                  sed 's/\r//g' "$WF_FILE"
-                  sed 's/\r//g' "$WF_FILE" | grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1
-                  WF_NAME=$(sed 's/\r//g' "$WF_FILE" | grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1)
+                  WF_NAME=$(sed 's/\r//g' "$WF_FILE" | { grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1 || true; })
                   if [[ ! -z "$WF_NAME" ]]; then
                     echo -n "Disabling the Actions file '$WF_FILE' named '$WF_NAME'... "
                     OUTPUT=$(gh workflow disable -R "$FORKED_REPO" "$WF_NAME" 2>&1)

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -357,7 +357,7 @@ jobs:
               env:
                 RELEASE_ORG: ${{ vars.RELEASE_ORG }}
                 FORKED_REPO: ${{ github.repository }}
-                GH_TOKEN: ${{ github.token }}
+                GH_TOKEN: ${{ steps.get_fork_writer_token.outputs.token }}
               run: |
                 for WF_FILE in $(find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +); do
                   WF_NAME=$(sed 's/\r//g' "$WF_FILE" | { grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1 || true; })

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -348,3 +348,22 @@ jobs:
                     echo "done"
                   fi
                 done
+
+            - name: Checkout the synced repo
+              uses: actions/checkout@v4
+            
+            - name: Automatically disable the actions which are not supposed to be executed in the fork
+              id: disable_upstream_actions
+              env:
+                RELEASE_ORG: ${{ vars.RELEASE_ORG }}
+                FORKED_REPO: ${{ github.repository }}
+                GH_TOKEN: ${{ github.token }}
+              run: |
+                for WF_FILE in $(find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +); do
+                  WF_NAME=$(sed 's/\r//g' "$WF_FILE" | grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1)
+                  if [[ ! -z "$WF_NAME" ]]; then
+                    echo -n "Disabling the Actions file '$WF_FILE' named '$WF_NAME'... "
+                    OUTPUT=$(gh workflow disable -R "$FORKED_REPO" "$WF_NAME" 2>&1)
+                    echo "done"
+                  fi
+                done

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -363,7 +363,7 @@ jobs:
                   WF_NAME=$(sed 's/\r//g' "$WF_FILE" | { grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1 || true; })
                   if [[ ! -z "$WF_NAME" ]]; then
                     echo -n "Disabling the Actions file '$WF_FILE' named '$WF_NAME'... "
-                    OUTPUT=$(gh workflow disable -R "$FORKED_REPO" "$WF_NAME" 2>&1)
+                    OUTPUT=$({ gh workflow disable -R "$FORKED_REPO" "$WF_NAME" 2>&1 || true; })
                     echo "done"
                   fi
                 done

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -359,11 +359,17 @@ jobs:
                 FORKED_REPO: ${{ github.repository }}
                 GH_TOKEN: ${{ steps.get_fork_writer_token.outputs.token }}
               run: |
-                for WF_FILE in $(find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +); do
-                  WF_NAME=$(sed 's/\r//g' "$WF_FILE" | { grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1 || true; })
-                  if [[ ! -z "$WF_NAME" ]]; then
-                    echo -n "Disabling the Actions file '$WF_FILE' named '$WF_NAME'... "
-                    OUTPUT=$({ gh workflow disable -R "$FORKED_REPO" "$WF_NAME" 2>&1 || true; })
-                    echo "done"
-                  fi
-                done
+                gh workflow list --all -R $FORKED_REPO --json name,state,id,path |\
+                  jq -r '.[] | [.name, .state, .id, .path] | @tsv' |\
+                  while IFS=$'\t' read -r WF_NAME WF_STATE WF_ID WF_PATH; do
+                    if [[ $WF_STATE == "active" ]]; then
+                      ORG_MARK=$(grep "$RELEASE_ORG/"	"$WF_PATH" 2>/dev/null)
+                      if [[ -n "$ORG_MARK" ]]; then
+                        echo "Skipping release workflow '$WF_NAME'"
+                      else
+                        echo -n "Disabling the Actions Workflow '$WF_NAME'... "
+                        OUTPUT=$(gh workflow disable -R "$FORKED_REPO" "$WF_ID" 2>&1)
+                        echo "done"
+                      fi
+                    fi
+                  done

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -362,7 +362,7 @@ jobs:
                 gh workflow list --all -R $FORKED_REPO --json name,state,id,path |\
                   jq -r '.[] | [.name, .state, .id, .path] | @tsv' |\
                   while IFS=$'\t' read -r WF_NAME WF_STATE WF_ID WF_PATH; do
-                    echo "WF_NAME WF_STATE WF_ID"
+                    echo "$WF_NAME $WF_STATE $WF_ID"
                     if [[ $WF_STATE == "active" ]]; then
                       ORG_MARK=$(grep "$RELEASE_ORG/"	"$WF_PATH" 2>/dev/null)
                       if [[ -n "$ORG_MARK" ]]; then

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -366,7 +366,8 @@ jobs:
                 find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +
                 echo ===
                 for WF_FILE in $(find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +); do
-                  echo "interation"
+                  sed 's/\r//g' "$WF_FILE"
+                  sed 's/\r//g' "$WF_FILE" | grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1
                   WF_NAME=$(sed 's/\r//g' "$WF_FILE" | grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1)
                   if [[ ! -z "$WF_NAME" ]]; then
                     echo -n "Disabling the Actions file '$WF_FILE' named '$WF_NAME'... "

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -359,6 +359,7 @@ jobs:
                 FORKED_REPO: ${{ github.repository }}
                 GH_TOKEN: ${{ github.token }}
               run: |
+                ls -alh
                 for WF_FILE in $(find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +); do
                   WF_NAME=$(sed 's/\r//g' "$WF_FILE" | grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1)
                   if [[ ! -z "$WF_NAME" ]]; then

--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -366,6 +366,7 @@ jobs:
                 find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +
                 echo ===
                 for WF_FILE in $(find .github -name "*.yml" -type f -exec grep -L "$RELEASE_ORG/" {} +); do
+                  echo "interation"
                   WF_NAME=$(sed 's/\r//g' "$WF_FILE" | grep '^name:[[:space:]]+\K(.+)\r?$' -Po -m 1)
                   if [[ ! -z "$WF_NAME" ]]; then
                     echo -n "Disabling the Actions file '$WF_FILE' named '$WF_NAME'... "

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ A specific input is `delete_non_matching_refs`, boolean (no quotes), default is 
 
 Omit the upstream code reader app part if you're sure that a standard GitHub token is OK (a public repos case). Fork writing app can't be omitted because of the undocumented Github API limitations, related to the `workflows: write` permission.
 
-The fork writer app must have the permissions: `contents: write` and the undocumented permission for the upstream merge API `workflows: write`.
+The fork writer app must have the permissions: 
+- `contents: write` and the undocumented permission for the upstream merge API `workflows: write`
+- `actions: write` to automatically disable the upstream actions in the fork
 
 Behaviour of the workflow is also controlled by the repo/org _variable_ `BRANCHES_TO_SYNC_EGREP_REGEX` - it defines which upstream branches should be in the fork. By default all the branches will be synced (not really good).
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The workflows are used to sync the forked repos between the GH orgs.
 
 It is needed to execute the controlled sync between the upstream and the fork.
 
+This workflow also automatically disables the actions that are supposed to be executed in the upstream repo only. They are identified by missing the string in the workflow file, equal to the RELEASE_ORG variable. Simply speaking, which don't have invocation of the workflows stored in this repository.
+
 Inputs: see the "inputs" and "secrets" section of the code, they are related to a Github application(s) that are able to read the upstream and write the fork.
 
 A specific input is `delete_non_matching_refs`, boolean (no quotes), default is `false`. When is set to `true`, it means that the refs (branches/tags), which exist in the fork, but do not exist in the upstream, will be wiped.


### PR DESCRIPTION
After syncing the repo content, some previously disabled actions can be self-enabled. The syncing action can now detect and disable them back.