### PR TITLE
Add concurrency_suffix input to check-synchronization

### DIFF
--- a/.github/workflows/check-synchronization.yml
+++ b/.github/workflows/check-synchronization.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
         default: master
+      concurrency_suffix: # optional suffix to make the concurrency group unique per caller
+        required: false
+        type: string
+        default: ''
     secrets:
       upstream_reader_app_key:
         required: false
@@ -31,7 +35,7 @@ on:
         value: ${{ jobs.job_check_branches_sync.outputs.refs_synced }}
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}${{ inputs.concurrency_suffix && format('-{0}', inputs.concurrency_suffix) || '' }}
 
 jobs:
   job_check_env_context:


### PR DESCRIPTION
## Summary

- When multiple callers invoke `check-synchronization` in parallel within the same workflow run (e.g. from a combined publish workflow), they all resolve to the same concurrency group (`repo-workflow-ref`) and GitHub randomly cancels competing jobs.
- Adds an optional `concurrency_suffix` input (default: empty) that callers can use to make the concurrency group unique per caller.
- Backwards compatible — existing callers without the suffix get the same behavior as before.

Related: https://github.com/paritytech/polkadot-sdk/pull/11703

## Test plan

- [ ] Existing callers without `concurrency_suffix` behave unchanged
- [ ] Combined workflow callers passing unique suffixes no longer get random cancellations